### PR TITLE
Memory override feature from ForeverZer0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ on it. This will free any memory the vector allocated during use.
 vec_deinit(&v);
 ```
 
+To use your own custom memory allocator, define both `VEC_FREE` and `VEC_REALLOC`
+before including `vec.h`, and they will be used instead of the standard library's
+`free` and `realloc`. 
 
 ## Types
 vec.h provides the following predefined vector types:

--- a/src/vec.c
+++ b/src/vec.c
@@ -12,7 +12,7 @@ int vec_expand_(char **data, int *length, int *capacity, int memsz) {
   if (*length + 1 > *capacity) {
     void *ptr;
     int n = (*capacity == 0) ? 1 : *capacity << 1;
-    ptr = realloc(*data, n * memsz);
+    ptr = VEC_REALLOC(*data, n * memsz);
     if (ptr == NULL) return -1;
     *data = ptr;
     *capacity = n;
@@ -24,7 +24,7 @@ int vec_expand_(char **data, int *length, int *capacity, int memsz) {
 int vec_reserve_(char **data, int *length, int *capacity, int memsz, int n) {
   (void) length;
   if (n > *capacity) {
-    void *ptr = realloc(*data, n * memsz);
+    void *ptr = VEC_REALLOC(*data, n * memsz);
     if (ptr == NULL) return -1;
     *data = ptr;
     *capacity = n;
@@ -45,14 +45,14 @@ int vec_reserve_po2_(
 
 int vec_compact_(char **data, int *length, int *capacity, int memsz) {
   if (*length == 0) {
-    free(*data);
+    VEC_FREE(*data);
     *data = NULL;
     *capacity = 0;
     return 0;
   } else {
     void *ptr;
     int n = *length;
-    ptr = realloc(*data, n * memsz);
+    ptr = VEC_REALLOC(*data, n * memsz);
     if (ptr == NULL) return -1;
     *capacity = n;
     *data = ptr;

--- a/src/vec.h
+++ b/src/vec.h
@@ -156,12 +156,12 @@
 
 
 
-#if defined(VEC_FREE) && (defined(VEC_REALLOC)
+#if defined(VEC_FREE) && defined(VEC_REALLOC)
 // Both defined, no error
 #elif !defined(VEC_REALLOC) && !defined(VEC_FREE)
 // Neither defined, use stdlib
-#define VEC_FREE(x) free
-#define VEC_REALLOC(x) realloc
+#define VEC_FREE free
+#define VEC_REALLOC realloc
 #else
 #error "Must define all or none of VEC_FREE and VEC_REALLOC."
 #endif

--- a/src/vec.h
+++ b/src/vec.h
@@ -155,6 +155,7 @@
         --(iter))
 
 
+
 #if defined(VEC_FREE) && (defined(VEC_REALLOC)
 // Both defined, no error
 #elif !defined(VEC_REALLOC) && !defined(VEC_FREE)

--- a/src/vec.h
+++ b/src/vec.h
@@ -27,7 +27,7 @@
 
 
 #define vec_deinit(v)\
-  ( free((v)->data),\
+  ( VEC_FREE((v)->data),\
     vec_init(v) ) 
 
 
@@ -154,6 +154,16 @@
         (iter) >= 0 && (((var) = &(v)->data[(iter)]), 1);\
         --(iter))
 
+
+#if defined(VEC_FREE) && (defined(VEC_REALLOC)
+// Both defined, no error
+#elif !defined(VEC_REALLOC) && !defined(VEC_FREE)
+// Neither defined, use stdlib
+#define VEC_FREE(x) free
+#define VEC_REALLOC(x) realloc
+#else
+#error "Must define all or none of VEC_FREE and VEC_REALLOC."
+#endif
 
 
 int vec_expand_(char **data, int *length, int *capacity, int memsz);


### PR DESCRIPTION
ForeverZer0:
> Added functionality for users to define VEC_FREE and VEC_REALLOC prior to including the vec.h header to have the library use those for memory allocation and freeing instead of the standard library.
> 
> If neither are present, they default to the standard library, and if only one of the two is defined it issues a compiler error.