### PR TITLE
Removing magic, intro vec_size_t and fix vec_pop

### DIFF
--- a/src/vec.c
+++ b/src/vec.c
@@ -8,7 +8,7 @@
 #include "vec.h"
 #include <string.h>
 
-int vec_expand_(uint8_t **data, const size_t *length, size_t *capacity, size_t memsz) {
+int vec_expand_(uint8_t **data, const vec_size_t *length, vec_size_t *capacity, vec_size_t memsz) {
   if (*length + 1 > *capacity) {
     void *ptr;
     int n = (*capacity == 0) ? 1 : *capacity << 1;
@@ -23,7 +23,7 @@ int vec_expand_(uint8_t **data, const size_t *length, size_t *capacity, size_t m
 }
 
 
-int vec_reserve_(uint8_t **data, const size_t *length, size_t *capacity, size_t memsz, size_t n) {
+int vec_reserve_(uint8_t **data, const vec_size_t *length, vec_size_t *capacity, vec_size_t memsz, vec_size_t n) {
   (void) length;
   if (n > *capacity) {
     uint8_t *ptr = VEC_REALLOC(*data, n * memsz);
@@ -37,8 +37,8 @@ int vec_reserve_(uint8_t **data, const size_t *length, size_t *capacity, size_t 
 }
 
 
-int vec_reserve_po2_(uint8_t **data, size_t *length, size_t *capacity, size_t memsz, size_t n) {
-  size_t n2 = 1;
+int vec_reserve_po2_(uint8_t **data, vec_size_t *length, vec_size_t *capacity, vec_size_t memsz, vec_size_t n) {
+  vec_size_t n2 = 1;
   if (n == 0) {
     return 0;
   }
@@ -49,14 +49,14 @@ int vec_reserve_po2_(uint8_t **data, size_t *length, size_t *capacity, size_t me
 }
 
 
-int vec_compact_(uint8_t **data, const size_t *length, size_t *capacity, size_t memsz) {
+int vec_compact_(uint8_t **data, const vec_size_t *length, vec_size_t *capacity, vec_size_t memsz) {
   if (*length == 0) {
     VEC_FREE(*data);
     *data = NULL;
     *capacity = 0;
   } else {
     void *ptr;
-    size_t n = *length;
+    vec_size_t n = *length;
     ptr = VEC_REALLOC(*data, n * memsz);
     if (ptr == NULL) {
         return -1;
@@ -68,7 +68,7 @@ int vec_compact_(uint8_t **data, const size_t *length, size_t *capacity, size_t 
 }
 
 
-int vec_insert_(uint8_t **data, size_t *length, size_t *capacity, size_t memsz, size_t idx) {
+int vec_insert_(uint8_t **data, vec_size_t *length, vec_size_t *capacity, vec_size_t memsz, vec_size_t idx) {
   int err = vec_expand_(data, length, capacity, memsz);
   if (err) {
     return err;
@@ -80,7 +80,7 @@ int vec_insert_(uint8_t **data, size_t *length, size_t *capacity, size_t memsz, 
 }
 
 
-void vec_splice_(uint8_t * const*data, const size_t *length, const size_t *capacity, size_t memsz, size_t start, size_t count) {
+void vec_splice_(uint8_t * const*data, const vec_size_t *length, const vec_size_t *capacity, vec_size_t memsz, vec_size_t start, vec_size_t count) {
   (void) capacity;
   memmove(*data + start * memsz,
           *data + (start + count) * memsz,
@@ -88,7 +88,7 @@ void vec_splice_(uint8_t * const*data, const size_t *length, const size_t *capac
 }
 
 
-void vec_swapsplice_(uint8_t *const *data, const size_t *length, const size_t *capacity, size_t memsz, size_t start, size_t count) {
+void vec_swapsplice_(uint8_t *const *data, const vec_size_t *length, const vec_size_t *capacity, vec_size_t memsz, vec_size_t start, vec_size_t count) {
   (void) capacity;
   memmove(*data + start * memsz,
           *data + (*length - count) * memsz,
@@ -96,7 +96,7 @@ void vec_swapsplice_(uint8_t *const *data, const size_t *length, const size_t *c
 }
 
 
-void vec_swap_(uint8_t *const *data, const size_t *length, const size_t *capacity, size_t memsz, size_t idx1, size_t idx2) {
+void vec_swap_(uint8_t *const *data, const vec_size_t *length, const vec_size_t *capacity, vec_size_t memsz, vec_size_t idx1, vec_size_t idx2) {
   unsigned char *a, *b, tmp;
   int count;
   (void) length;

--- a/src/vec.h
+++ b/src/vec.h
@@ -17,12 +17,19 @@
 #define VEC_OK 0
 #define VEC_NOT_FOUND ((size_t)VEC_ERR)
 
+// If a different size type is desired
+#if !defined(VEC_SIZE_TYPE)
+typedef size_t vec_size_t;
+#else
+typedef VEC_SIZE_TYPE vec_size_t;
+#endif
+
 #define vec_unpack_(v) \
   (uint8_t**)&(v)->data, &(v)->length, &(v)->capacity, sizeof(*(v)->data)
 
 
 #define vec_t(T) \
-  struct { T *data; size_t length, capacity; }
+  struct { T *data; vec_size_t length, capacity; }
 
 
 #define vec_init(v) \
@@ -97,11 +104,11 @@
 
 
 #define vec_first(v) \
-  (v)->data[0]
+  ((v)->data[0])
 
 
 #define vec_last(v) \
-  (v)->data[(v)->length - 1]
+  ((v)->data[(v)->length - 1])
 
 
 #define vec_reserve(v, n)          \
@@ -118,7 +125,7 @@
 
 #define vec_pusharr(v, arr, count)                                       \
   do {                                                                   \
-    size_t i__, n__ = (count);                                           \
+    vec_size_t i__, n__ = (count);                                           \
     if (vec_reserve_po2_(vec_unpack_(v), (v)->length + n__) != 0) break; \
     for (i__ = 0; i__ < n__; i__++) {                                    \
       (v)->data[(v)->length++] = (arr)[i__];                             \
@@ -140,7 +147,7 @@
 
 #define vec_remove(v, val)                    \
   do {                                        \
-    size_t idx__;                             \
+    vec_size_t idx__;                             \
     vec_find(v, val, idx__);                  \
     if (idx__ != VEC_NOT_FOUND) {             \
       vec_splice(v, idx__, 1);                \
@@ -150,7 +157,7 @@
 
 #define vec_reverse(v)                             \
   do {                                             \
-    size_t i__ = (v)->length >> 1;                 \
+    vec_size_t i__ = (v)->length >> 1;                 \
     while (i__--) {                                \
       vec_swap((v), i__, (v)->length - (i__ + 1)); \
     }                                              \
@@ -197,21 +204,21 @@
 #endif
 
 
-int vec_expand_(uint8_t **data, const size_t *length, size_t *capacity, size_t memsz);
+int vec_expand_(uint8_t **data, const vec_size_t *length, vec_size_t *capacity, vec_size_t memsz);
 
-int vec_reserve_(uint8_t **data, const size_t *length, size_t *capacity, size_t memsz, size_t n);
+int vec_reserve_(uint8_t **data, const vec_size_t *length, vec_size_t *capacity, vec_size_t memsz, vec_size_t n);
 
-int vec_reserve_po2_(uint8_t **data, size_t *length, size_t *capacity, size_t memsz, size_t n);
+int vec_reserve_po2_(uint8_t **data, vec_size_t *length, vec_size_t *capacity, vec_size_t memsz, vec_size_t n);
 
-int vec_compact_(uint8_t **data, const size_t *length, size_t *capacity, size_t memsz);
+int vec_compact_(uint8_t **data, const vec_size_t *length, vec_size_t *capacity, vec_size_t memsz);
 
-int vec_insert_(uint8_t **data, size_t *length, size_t *capacity, size_t memsz, size_t idx);
+int vec_insert_(uint8_t **data, vec_size_t *length, vec_size_t *capacity, vec_size_t memsz, vec_size_t idx);
 
-void vec_splice_(uint8_t *const *data, const size_t *length, const size_t *capacity, size_t memsz, size_t start, size_t count);
+void vec_splice_(uint8_t *const *data, const vec_size_t *length, const vec_size_t *capacity, vec_size_t memsz, vec_size_t start, vec_size_t count);
 
-void vec_swapsplice_(uint8_t *const *data, const size_t *length, const size_t *capacity, size_t memsz, size_t start, size_t count);
+void vec_swapsplice_(uint8_t *const *data, const vec_size_t *length, const vec_size_t *capacity, vec_size_t memsz, vec_size_t start, vec_size_t count);
 
-void vec_swap_(uint8_t *const *data, const size_t *length, const size_t *capacity, size_t memsz, size_t idx1, size_t idx2);
+void vec_swap_(uint8_t *const *data, const vec_size_t *length, const vec_size_t *capacity, vec_size_t memsz, vec_size_t idx1, vec_size_t idx2);
 
 
 typedef vec_t(void*) vec_void_t;

--- a/src/vec.h
+++ b/src/vec.h
@@ -55,7 +55,7 @@ typedef VEC_SIZE_TYPE vec_size_t;
 
 
 #define vec_pop(v) \
-  (v)->data[--(v)->length]
+  ((v)->length > 0 ? (--(v)->length) : 0)
 
 
 #define vec_splice(v, start, count)\
@@ -109,6 +109,10 @@ typedef VEC_SIZE_TYPE vec_size_t;
 
 #define vec_first(v) \
   ((v)->data[0])
+
+
+#define vec_empty(v) \
+  ((v)->length == 0)
 
 
 #define vec_last(v) \

--- a/src/vec.h
+++ b/src/vec.h
@@ -14,8 +14,12 @@
 
 #define VEC_VERSION "0.3.0"
 #define VEC_ERR -1
+#define VEC_ERR_MEMORY -2
 #define VEC_OK 0
-#define VEC_NOT_FOUND ((size_t)VEC_ERR)
+#define VEC_NOT_FOUND ((vec_size_t)VEC_ERR)
+
+#define VEC_INIT_CAPACITY 8
+#define VEC_GROW_CAPACITY(n) (((n) << 1) + (n >> 1))
 
 // If a different size type is desired
 #if !defined(VEC_SIZE_TYPE)

--- a/test/test_custom.c
+++ b/test/test_custom.c
@@ -1,0 +1,4 @@
+//
+// Created by Jacob on 2/9/22.
+//
+

--- a/test/test_custom.c
+++ b/test/test_custom.c
@@ -1,4 +1,9 @@
-//
-// Created by Jacob on 2/9/22.
-//
 
+#include "vec.h"
+#include "test_help.h"
+
+
+
+int main() {
+
+}

--- a/test/test_custom.c
+++ b/test/test_custom.c
@@ -1,9 +1,0 @@
-
-#include "vec.h"
-#include "test_help.h"
-
-
-
-int main() {
-
-}

--- a/test/test_help.h
+++ b/test/test_help.h
@@ -1,8 +1,29 @@
-//
-// Created by Jacob on 2/9/22.
-//
 
-#ifndef VEC_TEST_HELP_H
-#define VEC_TEST_HELP_H
 
-#endif //VEC_TEST_HELP_H
+#ifndef INCLUDED_VEC_TEST_HELP_H
+#define INCLUDED_VEC_TEST_HELP_H
+
+
+
+#define test_section(desc)\
+  do {\
+    printf("--- %s\n", desc);\
+  } while (0)
+
+#define test_assert(cond)\
+  do {\
+    int pass__ = cond;\
+    printf("[%s] %s:%d: ", pass__ ? "PASS" : "FAIL", __FILE__, __LINE__);\
+    printf((strlen(#cond) > 50 ? "%.47s...\n" : "%s\n"), #cond);\
+    if (pass__) { pass_count++; } else { fail_count++; }\
+  } while (0)
+
+#define test_print_res()\
+  do {\
+    printf("------------------------------------------------------------\n");\
+    printf("-- Results:   %3d Total    %3d Passed    %3d Failed       --\n",\
+           pass_count + fail_count, pass_count, fail_count);\
+    printf("------------------------------------------------------------\n");\
+  } while (0)
+
+#endif // INCLUDED_VEC_TEST_HELP_H

--- a/test/test_help.h
+++ b/test/test_help.h
@@ -1,0 +1,8 @@
+//
+// Created by Jacob on 2/9/22.
+//
+
+#ifndef VEC_TEST_HELP_H
+#define VEC_TEST_HELP_H
+
+#endif //VEC_TEST_HELP_H

--- a/test/test_vec.c
+++ b/test/test_vec.c
@@ -3,39 +3,31 @@
 #include <string.h>
 
 #include "vec.h"
-
-
-#define test_section(desc)\
-  do {\
-    printf("--- %s\n", desc);\
-  } while (0)
-
-#define test_assert(cond)\
-  do {\
-    int pass__ = cond;\
-    printf("[%s] %s:%d: ", pass__ ? "PASS" : "FAIL", __FILE__, __LINE__);\
-    printf((strlen(#cond) > 50 ? "%.47s...\n" : "%s\n"), #cond);\
-    if (pass__) { pass_count++; } else { fail_count++; }\
-  } while (0)
-
-#define test_print_res()\
-  do {\
-    printf("------------------------------------------------------------\n");\
-    printf("-- Results:   %3d Total    %3d Passed    %3d Failed       --\n",\
-           pass_count + fail_count, pass_count, fail_count);\
-    printf("------------------------------------------------------------\n");\
-  } while (0)
+#include "test_help.h"
 
 int pass_count = 0;
 int fail_count = 0;
 
+#define ITEM_NAME_SIZE 32
+
+typedef struct item_t {
+    int a;
+    int b;
+    char name[ITEM_NAME_SIZE];
+} item_t;
+
+typedef vec_t(item_t) vec_item_t;
 
 int intptrcmp(const void *a_, const void *b_) {
   const int *a = a_, *b = b_;
   return *a < *b ? -1 : *a > *b;
 }
 
-
+void test_assert_item(item_t *i, int a, int b, const char *s) {
+    test_assert(i->a == a);
+    test_assert(i->b == b);
+    test_assert(!strcmp(i->name, s));
+}
 
 int main(void) {
 
@@ -368,7 +360,15 @@ int main(void) {
     test_assert(acc == (19 + 2) * (31 + 1) * (47 + 0));
     vec_deinit(&v);
   }
-
+  { test_section("vec_custom_item");
+    vec_item_t v;
+    vec_init(&v);
+    item_t i = { 1, 2, "1" };
+    vec_push(&v, i);
+    test_assert_item(&vec_last(&v), 1, 2, "1");
+    vec_pop(&v);
+    vec_deinit(&v);
+  }
   test_print_res();
 
   return 0;

--- a/test/test_vec.c
+++ b/test/test_vec.c
@@ -48,9 +48,9 @@ int main(void) {
     vec_push(&v, 123);
     vec_push(&v, 456);
     vec_push(&v, 789);
-    test_assert(vec_pop(&v) == 789);
-    test_assert(vec_pop(&v) == 456);
-    test_assert(vec_pop(&v) == 123);
+    test_assert(!vec_empty(&v) && vec_last(&v) == 789 && vec_pop(&v) == 2);
+    test_assert(!vec_empty(&v) && vec_last(&v) == 456 && vec_pop(&v) == 1);
+    test_assert(!vec_empty(&v) && vec_last(&v) == 123 && vec_pop(&v) == 0);
     vec_deinit(&v);
   }
 


### PR DESCRIPTION
Removing magic numbers like 0 and -1, makes room for more specific error codes
Converting from size_t to vec_size_t to give more flexibility to integrations
Added test case for custom array type of struct