### PR TITLE
New functional APIs, improve bulk APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(VEC_TEST_SOURCES
         test/test_stats.c
         test/test_vec_custom.c
         test/test_vec_fixed.c
+        test/test_vec_functional.c
         test/test_vec_ops.c
         test/test_mem.c
         test/test_vec_mem_failures.c

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Copyright (c) 2014 rxi
 
+v0.3.x modifications (c) 2022 Jacob Repp (https://github.com/jrepp/vec)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/vec.c
+++ b/src/vec.c
@@ -1,8 +1,10 @@
 /** 
- * Copyright (c) 2014 rxi
+ * Copyright (c) 2014 rxi (https://github.com/rxi/vec)
+ *
+ * v0.3.x modifications (c) 2022 Jacob Repp (https://github.com/jrepp/vec)
  *
  * This library is free software; you can redistribute it and/or modify it
- * under the terms of the MIT license. See LICENSE for details.
+ * under the terms of the MIT license. See https://github.com/rxi/vec/LICENSE for details.
  */
 
 #include "vec.h"

--- a/src/vec.c
+++ b/src/vec.c
@@ -17,6 +17,7 @@ static uint8_t *vec_alloc_mem_(uint8_t *existing, vec_size_t *options, size_t ex
       *options |= VEC_OWNS_MEMORY;
       return new_region;
     }
+    *options |= VEC_OOM;
     return NULL;
   }
 
@@ -31,7 +32,8 @@ int vec_expand_(uint8_t **data, vec_size_t *options, const vec_size_t *length, v
     size_t new_capacity = (*capacity == 0) ? VEC_INIT_CAPACITY : VEC_GROW_CAPACITY(*capacity);
     uint8_t* ptr = vec_alloc_mem_(*data, options, *length * memsz, new_capacity * memsz);
     if (ptr == NULL) {
-        return VEC_ERR_NO_MEMORY;
+      *options |= VEC_OOM;
+      return VEC_ERR_NO_MEMORY;
     }
     *data = ptr;
     *capacity = new_capacity;
@@ -48,7 +50,8 @@ int vec_reserve_(uint8_t **data, vec_size_t *options, const vec_size_t *length, 
     }
     uint8_t *ptr = vec_alloc_mem_(*data, options, *length * memsz, n * memsz);
     if (ptr == NULL) {
-        return VEC_ERR_NO_MEMORY;
+      *options |= VEC_OOM;
+      return VEC_ERR_NO_MEMORY;
     }
     *data = ptr;
     *capacity = n;
@@ -72,7 +75,8 @@ int vec_compact_(uint8_t **data, vec_size_t *options, const size_t *length, vec_
     vec_size_t n = *length;
     uint8_t *ptr = vec_alloc_mem_(*data, options, *capacity * memsz, n * memsz);
     if (ptr == NULL) {
-        return VEC_ERR_NO_MEMORY;
+      *options |= VEC_OOM;
+      return VEC_ERR_NO_MEMORY;
     }
     *capacity = n;
     *data = ptr;

--- a/src/vec.h
+++ b/src/vec.h
@@ -1,8 +1,10 @@
 /** 
- * Copyright (c) 2014 rxi
+ * Copyright (c) 2014 rxi (https://github.com/rxi/vec)
+ *
+ * v0.3.x modifications (c) 2022 Jacob Repp (https://github.com/jrepp/vec)
  *
  * This library is free software; you can redistribute it and/or modify it
- * under the terms of the MIT license. See LICENSE for details.
+ * under the terms of the MIT license. See https://github.com/rxi/vec/LICENSE for details.
  */
 
 #ifndef INCLUDED_VEC_H
@@ -304,6 +306,40 @@ extern "C" {
          (iter) >= 0 && (((var) = &(v)->data[(iter)]), 1); \
          --(iter))
 
+
+// Apply function f(v->data[i])) to each element of v in-place
+#define vec_map_inplace(v, f) \
+  for (vec_size_t i__ = 0, l__ = (v)->length; i__ < l__; ++i__) { \
+    (v)->data[i__] = (f)((v)->data[i__]); \
+  }
+
+
+// Apply functional transform f(v->data[i], &v2->data[i]) to each element of v
+#define vec_map(v, v2, f) \
+  do {                    \
+    vec_reserve((v2), vec_length(v)); \
+    (v2)->length = (v)->length; \
+    for (vec_size_t i__ = 0, l__ = (v)->length; i__ < l__; ++i__) { \
+      (v2)->data[i__] = (f)((v)->data[i__]);                        \
+    } \
+  } while(0);
+
+
+// Apply functional fold to ov = f(v->data[i], ov) for each element of v
+#define vec_fold(v, ov, f) \
+  do {                     \
+    for (vec_size_t i__ = 0, l__ = (v)->length; i__ < l__; ++i__) { \
+      ov = (f)(ov, (v)->data[i__]);                       \
+    } \
+  } while(0);
+
+// Apply expression fold to (expr) (v->data[i]) for each element of v
+#define vec_fold_expr(v, expr) \
+  do {                     \
+    for (vec_size_t i__ = 0, l__ = (v)->length; i__ < l__; ++i__) { \
+      expr ((v)->data[i__]);                       \
+    } \
+  } while(0);
 
 int VEC_API(vec_expand_)(uint8_t **data, vec_size_t *options, const size_t *length, vec_size_t *capacity, vec_size_t memsz);
 

--- a/src/vec.h
+++ b/src/vec.h
@@ -50,8 +50,9 @@ extern "C" {
 //
 // Options for vectors
 //
-#define VEC_OWNS_MEMORY 0x10
-#define VEC_ALLOW_REALLOC 0x20
+#define VEC_OWNS_MEMORY     0x10
+#define VEC_ALLOW_REALLOC   0x20
+#define VEC_OOM             0x01
 
 //
 // Combinations of options for vector initialization
@@ -104,6 +105,11 @@ extern "C" {
 
 // Capacity of vector in elements
 #define vec_capacity(v) ((v)->capacity)
+
+
+// True when the vector has observed an oom condition, useful for error checking
+// after batch operations such as pusharr that don't have a natural return code.
+#define vec_oom(v) (((v)->options & VEC_OOM) == VEC_OOM)
 
 
 // Availability of vector in elements

--- a/src/vec_config_default.h
+++ b/src/vec_config_default.h
@@ -1,7 +1,3 @@
-//
-// Created by Jacob on 2/10/22.
-//
-
 #ifndef INCLUDED_VEC_CONFIG_DEFAULT_H
 #define INCLUDED_VEC_CONFIG_DEFAULT_H
 #include <stddef.h>

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -3,6 +3,7 @@
 extern int test_vec_ops();
 extern int test_vec_custom();
 extern int test_vec_fixed();
+extern int test_vec_functional();
 extern int test_vec_mem_failures();
 
 typedef int (*test_func)(void);
@@ -16,7 +17,8 @@ test_suite_t tests[] = {
   { "vec_ops", test_vec_ops },
   { "vec_custom", test_vec_custom },
   { "vec_fixed", test_vec_fixed },
-  { "vec_mem_failures", test_vec_mem_failures }
+  { "vec_functional", test_vec_functional },
+  { "vec_mem_failures", test_vec_mem_failures },
 };
 
 int main() {

--- a/test/test_vec_functional.c
+++ b/test/test_vec_functional.c
@@ -1,0 +1,4 @@
+//
+// Created by Jacob on 2/11/22.
+//
+

--- a/test/test_vec_functional.c
+++ b/test/test_vec_functional.c
@@ -1,6 +1,6 @@
 #include "test_help.h"
 
-static const int count = 1000;
+static const vec_size_t count = 1000;
 
 static int64_t power(int64_t value) {
   return value * 10;
@@ -11,7 +11,7 @@ static int64_t sum(int64_t out, int64_t in) {
 }
 
 static void fill_vec(vec_int64_t *v) {
-  for (int64_t i = 0; i < count; ++i) {
+  for (int64_t i = 0; i < (int64_t)count; ++i) {
     if (VEC_OK != vec_push(v, i)) {
       break;
     }

--- a/test/test_vec_functional.c
+++ b/test/test_vec_functional.c
@@ -1,4 +1,79 @@
-//
-// Created by Jacob on 2/11/22.
-//
+#include "test_help.h"
 
+static const int count = 1000;
+
+static int64_t power(int64_t value) {
+  return value * 10;
+}
+
+static int64_t sum(int64_t out, int64_t in) {
+  return out + in;
+}
+
+static void fill_vec(vec_int64_t *v) {
+  for (int64_t i = 0; i < count; ++i) {
+    if (VEC_OK != vec_push(v, i)) {
+      break;
+    }
+  }
+}
+
+static void test_assert_power(vec_int64_t *v) {
+  int valid = 1;
+  for (int64_t i = 0; i < (int64_t)v->length; ++i) {
+    if (v->data[i] != i * 10) {
+      valid = 0;
+    }
+  }
+  test_assert(valid && "power check valid");
+}
+
+
+int test_vec_functional() {
+  { test_section("vec_map_inplace");
+    vec_int64_t v;
+    vec_init(&v);
+    fill_vec(&v);
+    vec_map_inplace(&v, power);
+    test_assert(v.length == count);
+    test_assert_power(&v);
+    vec_deinit(&v);
+  }
+
+  { test_section("vec_map");
+    vec_int64_t v, v2;
+    vec_init(&v);
+    vec_init(&v2);
+    fill_vec(&v);
+    fill_vec(&v2);
+    vec_map(&v, &v2, power);
+    test_assert(v.length == count);
+    test_assert_power(&v2);
+    vec_deinit(&v);
+    vec_deinit(&v2);
+  }
+
+  { test_section("vec_fold");
+    int64_t values[32];
+    vec_int64_t v;
+    int64_t output = 0;
+    vec_init_with_fixed(&v, values, vec_countof(values));
+    fill_vec(&v);
+    vec_fold(&v, output, sum);
+    test_assert(output == 496);
+    vec_deinit(&v);
+  }
+
+  { test_section("vec_fold_expr");
+    int64_t values[32];
+    vec_int64_t v;
+    int64_t output = 0;
+    vec_init_with_fixed(&v, values, vec_countof(values));
+    fill_vec(&v);
+    vec_fold_expr(&v, output +=);
+    test_assert(output == 496);
+    vec_deinit(&v);
+  }
+
+  return 0;
+}

--- a/test/vec_config_test.h
+++ b/test/vec_config_test.h
@@ -1,7 +1,3 @@
-//
-// Created by Jacob on 2/9/22.
-//
-
 #ifndef VEC_TEST_VEC_CONFIG_H
 #define VEC_TEST_VEC_CONFIG_H
 


### PR DESCRIPTION
In https://github.com/rxi/vec/issues/8 @JerwuQu pointed out the failure problem in bulk APIs, to address this an OOM flag has been added to options that indicates a failure to allocate memory during a bulk operation. The alternative reduces the type-safety feature of these APIs.

Additional APIs were added to simplify functional programming of the vector
`vec_map`, `vec_map_in_place`, `vec_fold`, `vec_fold_expr` 

These new APIs are being tested in my integration of vec with the apriltags library.